### PR TITLE
HTML-escaping of xss payload in result field of the query

### DIFF
--- a/src/web/db-access.jsp
+++ b/src/web/db-access.jsp
@@ -4,6 +4,7 @@
 <%@ page import="org.jivesoftware.util.StringUtils" %>
 <%@ page import="java.util.Arrays" %>
 <%@ page import="java.util.List" %>
+<%@ page import="org.apache.commons.text.StringEscapeUtils"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
@@ -50,7 +51,7 @@
             stmt = con.createStatement();
 
             // SQL
-            out.println("<p>Your query: <b>" + sql + "</b></p>");
+            out.println("<p>Your query: <b>" + StringEscapeUtils.escapeHtml4(sql) + "</b></p>");
             stmt.execute(sql);
             rs = stmt.getResultSet();
             if (rs == null) {


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-other-openfire-dbaccess-plugin/

### ⚙️ Description *

In the field used to visualize the result of the query, the characters used to craft the XSS are transformed in a way the are not dangerous any more

### 💻 Technical Description *

The XSS payload was inserted in the html template without escaping the dangerous characters. The fix is using the method that HTML-escapes dangerous characters in the apache.commons.text (already present in the pom of the project); the payload is now rendered in a safe way without causing xss


### 🐛 Proof of Concept (PoC) *

The video shows how the payload triggers the XSS after executing the query. The version of the plugin is the one on the marketplace

https://user-images.githubusercontent.com/62958189/105401803-de1eb880-5c26-11eb-94bd-3c14c113149b.mp4



### 🔥 Proof of Fix (PoF) *

The video shows that the payload doesn't trigger XSS anymore thantk to escaping some characters. The version of the plugin is 1.2.4-SNAPSHOT.


https://user-images.githubusercontent.com/62958189/105401844-e8d94d80-5c26-11eb-9e0b-1d17deb4e78e.mp4



### 👍 User Acceptance Testing (UAT)

After the fix, the page is still working correctly as before the fix and the XSS is not triggered anymore

